### PR TITLE
mbed-tls-try2 updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,7 @@ set(COMPONENT_REQUIRES
 register_component()
 
 target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)
+
+if(CONFIG_ASYNC_TCP_SSL_ENABLED)
+    target_compile_options(${COMPONENT_TARGET} PRIVATE -DASYNC_TCP_SSL_ENABLED)
+endif()

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -27,4 +27,10 @@ config ASYNC_TCP_USE_WDT
     help
         Enable WDT for the AsyncTCP task, so it will trigger if a handler is locking the thread.
 
+config ASYNC_TCP_SSL_ENABLED
+    bool "Enable SSL for AsyncTCP client"
+    default "n"
+    help
+        Enables mbedTLS support for AsyncTCP clients.
+
 endmenu

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -152,7 +152,10 @@ static bool _remove_events_with_arg(void * arg){
 }
 
 static void _handle_async_event(lwip_event_packet_t * e){
-    if(e->event == LWIP_TCP_CLEAR){
+    if(e->arg == NULL){
+        // do nothing when arg is NULL
+        //ets_printf("event arg == NULL: 0x%08x\n", e->recv.pcb);
+    } else if(e->event == LWIP_TCP_CLEAR){
         _remove_events_with_arg(e->arg);
     } else if(e->event == LWIP_TCP_RECV){
         //ets_printf("-R: 0x%08x\n", e->recv.pcb);

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -28,9 +28,6 @@ extern "C"{
 #include "lwip/inet.h"
 #include "lwip/dns.h"
 #include "lwip/err.h"
-#if ASYNC_TCP_SSL_ENABLED
-#include "tcp_mbedtls.h"
-#endif
 }
 #include "esp_task_wdt.h"
 
@@ -979,8 +976,7 @@ int8_t AsyncClient::_connected(void* pcb, int8_t err){
             bool err = false;
             if (_psk_ident != NULL and _psk != NULL) {
                 err = tcp_ssl_new_psk_client(_pcb, this, _psk_ident, _psk) < 0;
-            }
-            else {
+            } else {
                 err = tcp_ssl_new_client(_pcb, this, _hostname.empty() ? NULL : _hostname.c_str(),
                         _root_ca, _root_ca_len) < 0;
             }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -28,6 +28,9 @@ extern "C"{
 #include "lwip/inet.h"
 #include "lwip/dns.h"
 #include "lwip/err.h"
+#if ASYNC_TCP_SSL_ENABLED
+#include "tcp_mbedtls.h"
+#endif
 }
 #include "esp_task_wdt.h"
 

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -977,11 +977,12 @@ int8_t AsyncClient::_connected(void* pcb, int8_t err){
 #if ASYNC_TCP_SSL_ENABLED
         if(_pcb_secure){
             bool err = false;
-            if(_root_ca) {
+            if (_psk_ident != NULL and _psk != NULL) {
+                err = tcp_ssl_new_psk_client(_pcb, this, _psk_ident, _psk) < 0;
+            }
+            else {
                 err = tcp_ssl_new_client(_pcb, this, _hostname.empty() ? NULL : _hostname.c_str(),
                         _root_ca, _root_ca_len) < 0;
-            } else {
-                err = tcp_ssl_new_psk_client(_pcb, this, _psk_ident, _psk) < 0;
             }
             if (err) {
                 log_e("closing....");

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -26,8 +26,10 @@
 #include "sdkconfig.h"
 #include <functional>
 #include <string>
+#if ASYNC_TCP_SSL_ENABLED
 #include <ssl_client.h>
 #include "tcp_mbedtls.h"
+#endif
 extern "C" {
     #include "freertos/semphr.h"
     #include "lwip/pbuf.h"

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -297,6 +297,11 @@ int tcp_ssl_new_client(struct tcp_pcb *tcp, void *arg, const char* hostname, con
 int tcp_ssl_new_psk_client(struct tcp_pcb *tcp, void *arg, const char* psk_ident, const char* pskey) {
   tcp_ssl_t* tcp_ssl;
 
+  if (pskey == NULL || psk_ident == NULL) {
+    TCP_SSL_DEBUG(" failed\n  !  pre-shared key or identity is NULL\n\n");
+    return -1;
+  }
+
   if(tcp == NULL) return -1;
   if(tcp_ssl_get(tcp) != NULL) return -1;
 
@@ -324,11 +329,6 @@ int tcp_ssl_new_psk_client(struct tcp_pcb *tcp, void *arg, const char* psk_ident
   //mbedtls_esp_enable_debug_log(&tcp_ssl->ssl_conf, 4); // 4=verbose
 
   int ret = 0;
-
-  if (pskey == NULL || psk_ident == NULL) {
-    TCP_SSL_DEBUG(" failed\n  !  pre-shared key or identity is NULL\n\n");
-    return -1;
-  }
 
   TCP_SSL_DEBUG("setting the pre-shared key.\n");
   // convert PSK from hex string to binary

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -231,7 +231,7 @@ int tcp_ssl_new_client(struct tcp_pcb *tcp, void *arg, const char* hostname, con
   mbedtls_ssl_config_init(&tcp_ssl->ssl_conf);
 
   mbedtls_ctr_drbg_seed(&tcp_ssl->drbg_ctx, mbedtls_entropy_func,
-                        &tcp_ssl->entropy_ctx, (const unsigned char*)pers, strlen(pers));
+                        &tcp_ssl->entropy_ctx, (const unsigned char*)pers, sizeof(pers));
 
   if(mbedtls_ssl_config_defaults(&tcp_ssl->ssl_conf,
     MBEDTLS_SSL_IS_CLIENT,
@@ -309,7 +309,7 @@ int tcp_ssl_new_psk_client(struct tcp_pcb *tcp, void *arg, const char* psk_ident
   mbedtls_ssl_config_init(&tcp_ssl->ssl_conf);
 
   mbedtls_ctr_drbg_seed(&tcp_ssl->drbg_ctx, mbedtls_entropy_func,
-                        &tcp_ssl->entropy_ctx, (const uint8_t*)pers, strlen(pers));
+                        &tcp_ssl->entropy_ctx, (const uint8_t*)pers, sizeof(pers));
 
   if(mbedtls_ssl_config_defaults(&tcp_ssl->ssl_conf,
     MBEDTLS_SSL_IS_CLIENT,

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -325,6 +325,11 @@ int tcp_ssl_new_psk_client(struct tcp_pcb *tcp, void *arg, const char* psk_ident
 
   int ret = 0;
 
+  if (pskey == NULL || psk_ident == NULL) {
+    TCP_SSL_DEBUG(" failed\n  !  pre-shared key or identity is NULL\n\n");
+    return -1;
+  }
+
   TCP_SSL_DEBUG("setting the pre-shared key.\n");
   // convert PSK from hex string to binary
   if ((strlen(pskey) & 1) != 0 || strlen(pskey) > 2*MBEDTLS_PSK_MAX_LEN) {


### PR DESCRIPTION
- merge upstream to branch
- use sizeof instead of strlen for const char[]
- add kconfig option to enable/disable ASYNC_TCP_SSL_ENABLED
-- fix for cmake
- optionally include ssl headers
- add null check for pskey and psk_ident vars
- don't default to PSK when root ca not explicitly provided