### PR TITLE
Memory leak

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -631,10 +631,12 @@ AsyncClient::~AsyncClient(){
     if(_pcb) {
         _close();
     }
+#if ASYNC_TCP_SSL_ENABLED  
     else
     {
         tcp_ssl_free_by_arg(this);
-    }  
+    }
+#endif  
     _free_closed_slot();
 }
 

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -630,7 +630,9 @@ AsyncClient::AsyncClient(tcp_pcb* pcb)
 AsyncClient::~AsyncClient(){
     if(_pcb) {
         _close();
-    } else {
+    }
+    else
+    {
         tcp_ssl_free_by_arg(this);
     }  
     _free_closed_slot();

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -630,7 +630,9 @@ AsyncClient::AsyncClient(tcp_pcb* pcb)
 AsyncClient::~AsyncClient(){
     if(_pcb) {
         _close();
-    }
+    } else {
+        tcp_ssl_free_by_arg(this);
+    }  
     _free_closed_slot();
 }
 

--- a/src/tcp_mbedtls.h
+++ b/src/tcp_mbedtls.h
@@ -36,6 +36,7 @@ int tcp_ssl_write(struct tcp_pcb *tcp, uint8_t *data, size_t len);
 int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p);
 int tcp_ssl_handshake_step(struct tcp_pcb *tcp);
 int tcp_ssl_free(struct tcp_pcb *tcp);
+int tcp_ssl_free_by_arg(void * arg);
 bool tcp_ssl_has(struct tcp_pcb *tcp);
 void tcp_ssl_arg(struct tcp_pcb *tcp, void * arg);
 void tcp_ssl_data(struct tcp_pcb *tcp, tcp_ssl_data_cb_t arg);


### PR DESCRIPTION
I have found that there is a memory leak in the secure part of the AsyncClient. 
The problem can be seen simply when you create new AsyncClient by new, then connect to some secure server and then try to dealocate by delete. This will left about 40kB of memory somewhere.
This patch may solve it. Hope it helps.